### PR TITLE
Sort and send the subreddits with the number of mentions

### DIFF
--- a/lib/discover_reddit_bot/bot.ex
+++ b/lib/discover_reddit_bot/bot.ex
@@ -33,8 +33,6 @@ defmodule DiscoverRedditBot.Bot do
 
     if subreddits_detected != %{} do
       answer(context, message, parse_mode: "Markdown")
-    else
-      answer(context, TextFormatter.no_subreddits_text(), parse_mode: "Markdown")
     end
   end
 

--- a/lib/discover_reddit_bot/bot.ex
+++ b/lib/discover_reddit_bot/bot.ex
@@ -33,6 +33,8 @@ defmodule DiscoverRedditBot.Bot do
 
     if subreddits_detected != [] do
       answer(context, message, parse_mode: "Markdown")
+    else
+      answer(context, TextFormatter.no_subreddits_text(), parse_mode: "Markdown")
     end
   end
 

--- a/lib/discover_reddit_bot/parser.ex
+++ b/lib/discover_reddit_bot/parser.ex
@@ -1,31 +1,60 @@
 defmodule DiscoverRedditBot.Parser do
   alias DiscoverRedditBot.RedditClient
 
-  def extract_urls(text) do
-    text
-    |> String.split(~r/(\s|\n)/, trim: true)
-    |> Enum.filter(&String.match?(&1, ~r/^(http|https):\/\/(www\.|old\.|)reddit.com/))
-  end
+  @type subreddits :: [{String.t(), non_neg_integer()}]
 
   @doc """
   This function expects the full json from reddit as a string
+  and returns a map with key the subreddit name and value number
+  of occurrences
   """
-  @spec extract_subrredits(String.t()) :: {:ok, [String.t()]}
-  def extract_subrredits(text) do
-    Regex.scan(~r/[ ^\/](r\/[a-zA-Z0-9-_]+)\b/i, text)
-    |> Enum.reduce(MapSet.new(), fn [_, match | _], acc -> MapSet.put(acc, "/#{match}") end)
-    |> MapSet.to_list()
-  end
-
+  @spec get_subreddits(String.t()) :: subreddits
   def get_subreddits(text) do
     text
     |> extract_urls()
     |> Enum.map(fn url ->
       case RedditClient.get_comments(url) do
         {:ok, comments} -> extract_subrredits(comments)
-        _ -> []
+        _ -> %{}
       end
     end)
-    |> List.flatten()
+    |> merge_subreddits()
+    |> sort_subreddits()
+  end
+
+  defp extract_urls(text) do
+    text
+    |> String.split(~r/(\s|\n)/, trim: true)
+    |> Enum.filter(&String.match?(&1, ~r/^(http|https):\/\/(www\.|old\.|)reddit.com/))
+  end
+
+  defp extract_subrredits(text) do
+    Regex.scan(~r/[ ^\/](r\/[a-zA-Z0-9-_]+)\b/i, text)
+    |> Enum.reduce(%{}, fn [_, match | _], acc ->
+      name = "/" <> match
+      current = Map.get(acc, name, 0)
+
+      Map.put(acc, name, current + 1)
+    end)
+  end
+
+  defp merge_subreddits([sub]), do: sub
+
+  defp merge_subreddits([sub1, sub2 | rest]) do
+    merged = merge_subreddits(sub1, sub2)
+
+    merge_subreddits([merged | rest])
+  end
+
+  defp merge_subreddits(sub1, sub2) do
+    Enum.reduce(sub1, sub2, fn {k, sum}, acc ->
+      current = Map.get(acc, k, 0)
+
+      Map.put(acc, k, current + sum)
+    end)
+  end
+
+  defp sort_subreddits(subreddits) do
+    Enum.sort_by(subreddits, fn {_k, v} -> v end, &(&1 > &2))
   end
 end

--- a/lib/discover_reddit_bot/text_formatter.ex
+++ b/lib/discover_reddit_bot/text_formatter.ex
@@ -33,7 +33,7 @@ defmodule DiscoverRedditBot.TextFormatter do
           id: name,
           title: title,
           input_message_content: %InputTextMessageContent{
-            message_text: format_subreddit(data, :for_inline),
+            message_text: format_subreddit(data),
             parse_mode: "Markdown"
           }
         }
@@ -88,7 +88,7 @@ defmodule DiscoverRedditBot.TextFormatter do
 
   defp format_subreddit({sub, n}), do: "  - [#{sub}](#{reddit_base_url()}#{sub}) (#{n})"
 
-  defp format_subreddit({sub, n, urls}, :for_inline) do
+  defp format_subreddit({sub, n, urls}) do
     urls_text =
       urls
       |> Stream.map(fn url ->

--- a/lib/discover_reddit_bot/text_formatter.ex
+++ b/lib/discover_reddit_bot/text_formatter.ex
@@ -14,7 +14,7 @@ defmodule DiscoverRedditBot.TextFormatter do
         |> Stream.map(&format_subreddit/1)
         |> Enum.join("\n")
 
-      "Subreddits detected #{url}:\n#{subredits_message}"
+      "Subreddits detected [#{url}](#{url}):\n#{subredits_message}"
     end)
     |> Enum.join("\n\n")
   end

--- a/lib/discover_reddit_bot/text_formatter.ex
+++ b/lib/discover_reddit_bot/text_formatter.ex
@@ -1,29 +1,32 @@
 defmodule DiscoverRedditBot.TextFormatter do
   alias ExGram.Model.{InlineQueryResultArticle, InputTextMessageContent}
 
+  @type subreddits :: DiscoverRedditBot.Parser.subreddits()
+
   def reddit_base_url(), do: "https://www.reddit.com"
 
+  @spec format_subreddits(subreddits) :: String.t()
   def format_subreddits(subreddits) do
     subredits_message =
       subreddits
-      |> Enum.map(&format_subreddit/1)
+      |> Stream.map(&format_subreddit/1)
       |> Enum.join("\n")
 
     "Subreddits detected:\n#{subredits_message}"
   end
 
-  def format_subreddit(sub), do: "  - [#{sub}](#{reddit_base_url()}#{sub})"
-  def format_subreddit(sub, :for_inline), do: "[#{sub}](#{reddit_base_url()}#{sub})"
-
+  @spec get_inline_articles(subreddits) :: [InlineQueryResultArticle.t()]
   def get_inline_articles(subreddits) do
     articles =
-      Enum.map(subreddits, fn sub ->
+      Enum.map(subreddits, fn {name, n} = data ->
+        title = "#{name} (#{n})"
+
         %InlineQueryResultArticle{
           type: "article",
-          id: sub,
-          title: sub,
+          id: name,
+          title: title,
           input_message_content: %InputTextMessageContent{
-            message_text: format_subreddit(sub, :for_inline),
+            message_text: format_subreddit(data, :for_inline),
             parse_mode: "Markdown"
           }
         }
@@ -42,16 +45,27 @@ defmodule DiscoverRedditBot.TextFormatter do
     [all_article] ++ articles
   end
 
+  @spec no_subreddits_text :: String.t()
+  def no_subreddits_text() do
+    "No subreddits detected"
+  end
+
+  @spec get_no_subreddits_inline :: [InlineQueryResultArticle.t()]
   def get_no_subreddits_inline() do
+    text = no_subreddits_text()
+
     [
       %InlineQueryResultArticle{
         type: "article",
         id: "nosubs",
-        title: "No subreddits detected",
+        title: text,
         input_message_content: %InputTextMessageContent{
-          message_text: "No subreddits detected"
+          message_text: text
         }
       }
     ]
   end
+
+  defp format_subreddit({sub, n}), do: "  - [#{sub}](#{reddit_base_url()}#{sub}) (#{n})"
+  defp format_subreddit({sub, n}, :for_inline), do: "[#{sub}](#{reddit_base_url()}#{sub}) (#{n})"
 end


### PR DESCRIPTION
This PR adds the ability to know how many times the subreddit was mentioned, so the user will know which subreddit are more related to the provided URLs

Also it split the results by URL when sended in text, for example:

```
Subreddits detected [https://www.reddit.com/r/linux/comments/gb5esi/pop_os_2004_released/](https://www.reddit.com/r/linux/comments/gb5esi/pop_os_2004_released/):
  - [/r/linux](https://www.reddit.com/r/linux) (152)

Subreddits detected [https://www.reddit.com/r/science/comments/gb1hg4/researchers_tested_47_existing_drugs_that_protein/](https://www.reddit.com/r/science/comments/gb1hg4/researchers_tested_47_existing_drugs_that_protein/):
  - [/r/science](https://www.reddit.com/r/science) (187)
  - [/r/medicine](https://www.reddit.com/r/medicine) (2)
  - [/r/dxm](https://www.reddit.com/r/dxm) (1)
```

For inline articles it merge all the mentions to a subreddit, but the text sended when clicked send all the URLs where that subreddit was mentioned.