### PR TITLE
Parse response as JSON and extract only the comments body

### DIFF
--- a/lib/discover_reddit_bot/reddit_client.ex
+++ b/lib/discover_reddit_bot/reddit_client.ex
@@ -3,6 +3,8 @@ defmodule DiscoverRedditBot.RedditClient do
 
   require Logger
 
+  plug(Tesla.Middleware.JSON)
+
   def get_comments(url) do
     case get("#{url}.json") do
       {:ok, %{body: body}} ->


### PR DESCRIPTION
Right now using the full JSON as text there is a problem with repeated data (every comment includes comment, URL to comment, comment as HTML, ...), for example for this URL which only has one subreddit on the comments, it detect three times that subreddit and 18 the original where is posted:

```
Subreddits detected https://www.reddit.com/r/funny/comments/gcos67/_/ (https://www.reddit.com/r/funny/comments/gcos67/_/):
  - /r/funny (https://www.reddit.com/r/funny) (18)
  - /r/13or30 (https://www.reddit.com/r/13or30) (3)
```


This PR uses the JSON structure to extract only the comments & replies bodies